### PR TITLE
add trust to db

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -39,6 +39,7 @@ applications:
   db:
     charm: ./oai-db-operator/db.charm
     scale: 1
+    trust: true
     resources:
       oai-db-image: mysql:5.5
   gnb:


### PR DESCRIPTION
DB has to have trust because it trys to deploy a service in the _on_install event